### PR TITLE
bugfix: generated games were failing to upload properly

### DIFF
--- a/src/pandemic/PandemicDealServlet.java
+++ b/src/pandemic/PandemicDealServlet.java
@@ -219,6 +219,7 @@ public class PandemicDealServlet extends HttpServlet
 	void doPostDeal(HttpServletRequest req, HttpServletResponse resp, String deal_id)
 		throws IOException
 	{
+		log.info("new scenario received for " + deal_id);
 		String content = getRequestContent(req);
 		JsonParser json = new JsonFactory().
 			createJsonParser(new StringReader(content));
@@ -287,7 +288,8 @@ public class PandemicDealServlet extends HttpServlet
 
 		try
 		{
-			Key key = KeyFactory.createKey("Deal", deal_id);
+			Key key = KeyFactory.createKey("Scenario", deal_id);
+			log.info("key is " + key.toString());
 			Date createdDate = new Date();
 			String creatorIp = req.getRemoteAddr();
 
@@ -295,6 +297,7 @@ public class PandemicDealServlet extends HttpServlet
 			ent.setProperty("content", new Text(content));
 			ent.setProperty("version", versionString);
 			ent.setProperty("rules", r.toString());
+			ent.setProperty("playerCount", r.playerCount);
 
 		// WARNING: older version of playerRoles is /-separated string
 			ent.setProperty("playerRoles", playerRoles);
@@ -303,6 +306,8 @@ public class PandemicDealServlet extends HttpServlet
 			ent.setProperty("createdBy", creatorIp);
 
 			datastore.put(ent);
+			log.info("saved scenario");
+
 			txn.commit();
 
 			resp.setContentType("text/json;charset=UTF-8");

--- a/webapp/pandemic-game.js
+++ b/webapp/pandemic-game.js
@@ -279,7 +279,8 @@ function generate_scenario(rules)
 console.log('saving scenario ' + G.scenario_id);
 	localStorage.setItem(PACKAGE + '.scenario.' + G.scenario_id, XX);
 	stor_add_to_set(PACKAGE + '.scenarios_by_rules.' + stringify_rules(G.rules), G.scenario_id);
-	stor_add_to_set(PACKAGE + '.pending_scenario_uploads', G.scenario_id);
+	stor_add_to_set(PACKAGE + '.scenarios_by_player_count.' + G.rules.player_count, G.scenario_id);
+	stor_add_to_set(PACKAGE + '.pending_scenarios', G.scenario_id);
 
 	trigger_sync_process();
 


### PR DESCRIPTION
Scenarios generated by the user were failing to upload, meaning a user-generated game could not be joined from another device and the game could not be played again by anyone else.
